### PR TITLE
Allow salty-coffee to be used as a JPMS module

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module software.panda.crypto.nacl {
+	exports software.pando.crypto.nacl;
+}


### PR DESCRIPTION
Thanks for this very useful library! It helped me to implement a simple Java 11 client for the Threema messenger. As we're on Java 11 it would be nice to declare proper module dependencies.

This PR adds a simple module descriptor so the salty-coffee library can be used as a Java 11 module.