### PR TITLE
Merge release 1.0.5 new features and bugfixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019-2021 Neil Madden.
+  ~ Copyright 2019-2022 Neil Madden.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -70,13 +70,13 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.4.0</version>
+            <version>7.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.19.0</version>
+            <version>3.22.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spotbugs-security-exclude.xml
+++ b/spotbugs-security-exclude.xml
@@ -1,2 +1,8 @@
 <FindBugsFilter>
+    <Match>
+        <!-- Ignore warning about equalsIgnoreCase for comparing format/algorithm - this is not security-sensitive. -->
+        <Class name="software.pando.crypto.nacl.CryptoSecretKey"/>
+        <Method name="equals"/>
+        <Bug pattern="IMPROPER_UNICODE"/>
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/software/pando/crypto/nacl/ByteSlice.java
+++ b/src/main/java/software/pando/crypto/nacl/ByteSlice.java
@@ -51,6 +51,10 @@ public final class ByteSlice {
         return length;
     }
 
+    void wipe() {
+        Arrays.fill(array, offset, offset + length, (byte) 0);
+    }
+
     /**
      * Static factory method for constructing a slice from an input array. This method does not copy the array, so any
      * changes subsequently made to the array will be reflected in the contents of the slice, and vice versa. Use

--- a/src/main/java/software/pando/crypto/nacl/ByteSlice.java
+++ b/src/main/java/software/pando/crypto/nacl/ByteSlice.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2022 Neil Madden.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.pando.crypto.nacl;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Represents a slice of a byte array, represented as an offset and a length into that array.
+ */
+public final class ByteSlice {
+    final byte[] array;
+    final int offset;
+    final int length;
+
+    private ByteSlice(byte[] array, int offset, int length) {
+        this.array = Objects.requireNonNull(array, "array");
+        this.offset = Objects.checkFromIndexSize(offset, length, array.length);
+        this.length = length;
+    }
+
+    /**
+     * Converts the slice to a byte array. The returned array is always a copy of the underlying slice.
+     *
+     * @return a byte array copy of this slice.
+     */
+    public byte[] toByteArray() {
+        return Arrays.copyOfRange(array, offset, offset + length);
+    }
+
+    /**
+     * The number of bytes in the slice.
+     *
+     * @return the length of the slice, in bytes.
+     */
+    public int length() {
+        return length;
+    }
+
+    /**
+     * Static factory method for constructing a slice from an input array. This method does not copy the array, so any
+     * changes subsequently made to the array will be reflected in the contents of the slice, and vice versa. Use
+     * {@code array.clone()} if you wish to make the slice independent of the array.
+     *
+     * @param array the input byte array.
+     * @param offset the offset into the array at which to start the slice. This must be between 0 and the length of
+     *               the array.
+     * @param length the length of the slice. The length of the array must be at least offset+length bytes long.
+     * @return the constructed byte slice.
+     * @throws NullPointerException if the array is null.
+     * @throws IndexOutOfBoundsException if the offset or length are outside of the bounds of the provided array.
+     */
+    public static ByteSlice of(byte[] array, int offset, int length) {
+        return new ByteSlice(array, offset, length);
+    }
+
+    /**
+     * Static factory method for constructing a slice from an input array. This method does not copy the array, so any
+     * changes subsequently made to the array will be reflected in the contents of the slice, and vice versa. Use
+     * {@code array.clone()} if you wish to make the slice independent of the array.
+     *
+     * @param array the input byte array.
+     * @param from the offset into the array at which to start the slice (inclusive). This must be between 0 and less
+     *             than the length of the array.
+     * @param to the offset into the array at which to end the slice (exclusive).
+     * @return the constructed byte slice.
+     * @throws NullPointerException if the array is null.
+     * @throws IndexOutOfBoundsException if the offset or length are outside of the bounds of the provided array.
+     */
+    public static ByteSlice ofRange(byte[] array, int from, int to) {
+        Objects.checkFromToIndex(from, to, array.length);
+        return of(array, from, to - from);
+    }
+
+    /**
+     * Static factory method for constructing a slice from an input array. This method does not copy the array, so any
+     * changes subsequently made to the array will be reflected in the contents of the slice, and vice versa. Use
+     * {@code array.clone()} if you wish to make the slice independent of the array.
+     *
+     * @param array the input byte array.
+     * @param offset the offset into the array at which to start the slice. This must be between 0 and the length of
+     *               the array. The slice will cover the array from the given offset until the end of the array.
+     * @return the constructed byte slice.
+     * @throws NullPointerException if the array is null.
+     * @throws IndexOutOfBoundsException if the offset is outside of the bounds of the provided array.
+     */
+    public static ByteSlice of(byte[] array, int offset) {
+        return of(array, offset, array.length - offset);
+    }
+
+    /**
+     * Static factory method for constructing a slice from an input array. This method does not copy the array, so any
+     * changes subsequently made to the array will be reflected in the contents of the slice, and vice versa. Use
+     * {@code array.clone()} if you wish to make the slice independent of the array. The constructed slice will cover
+     * the entire contents of the array.
+     *
+     * @param array the input byte array.
+     * @return the constructed byte slice.
+     * @throws NullPointerException if the array is null.
+     */
+    public static ByteSlice of(byte[] array) {
+        return of(array, 0);
+    }
+}

--- a/src/main/java/software/pando/crypto/nacl/Bytes.java
+++ b/src/main/java/software/pando/crypto/nacl/Bytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Neil Madden.
+ * Copyright 2019-2022 Neil Madden.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,16 @@ package software.pando.crypto.nacl;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 
 /**
  * Generic utilities for operating on byte arrays that may contain secret data.
  */
 public final class Bytes {
+    private static final Collection<String> PREFERRED_PRNGS = List.of(
+            "NativePRNGNonBlocking", "NativePRNG", "DRBG");
     private static final SecureRandom SECURE_RANDOM_SOURCE = getSecureRandomInstance();
 
     /**
@@ -80,19 +84,31 @@ public final class Bytes {
     }
 
     /**
+     * Concatenates three byte arrays. A new array is always created even if one of the arguments is zero-length.
+     *
+     * @param a the first byte array.
+     * @param b the second byte array.
+     * @param c the third byte array.
+     * @return the concatenation of the two byte arrays.
+     */
+    static byte[] concat(byte[] a, byte[] b, byte[] c) {
+        byte[] d = new byte[a.length + b.length + c.length];
+        System.arraycopy(a, 0, d, 0, a.length);
+        System.arraycopy(b, 0, d, a.length, b.length);
+        System.arraycopy(c, 0, d, a.length + b.length, c.length);
+        return d;
+    }
+
+    /**
      * Swaps two elements of a byte array.
      */
     private static void swap(byte[] bytes, int x, int y) {
-        assert x != y;
-        bytes[x] ^= bytes[y];
-        bytes[y] ^= bytes[x];
-        bytes[x] ^= bytes[y];
+        byte tmp = bytes[x];
+        bytes[x] = bytes[y];
+        bytes[y] = tmp;
     }
 
     private static SecureRandom getSecureRandomInstance() {
-        final String[] PREFERRED_PRNGS = {
-                "NativePRNGNonBlocking", "NativePRNG", "DRBG"
-        };
         for (String alg : PREFERRED_PRNGS) {
             try {
                 return SecureRandom.getInstance(alg);

--- a/src/main/java/software/pando/crypto/nacl/Crypto.java
+++ b/src/main/java/software/pando/crypto/nacl/Crypto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Neil Madden.
+ * Copyright 2019-2022 Neil Madden.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 package software.pando.crypto.nacl;
 
+import javax.crypto.SecretKey;
+import javax.security.auth.Destroyable;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.Arrays;
-
-import javax.crypto.SecretKey;
 
 /**
  * The main interface to all cryptographic operations provided by this library.
@@ -80,13 +80,25 @@ public final class Crypto {
      * Converts the given bytes into a secret key for use with {@link #auth(SecretKey, byte[])}.
      *
      * @param keyBytes the key bytes.
-     * @return the secret key.
+     * @return the secret key. The returned key can be {@linkplain Destroyable#destroy() destroyed} when no longer
+     * required.
      */
     public static SecretKey authKey(byte[] keyBytes) {
         if (keyBytes.length != SHA512.HMAC_KEY_LEN) {
             throw new IllegalArgumentException("invalid key");
         }
         return new CryptoSecretKey(keyBytes, SHA512.MAC_ALGORITHM);
+    }
+
+    /**
+     * Converts the given bytes into a secret key for use with {@link #auth(SecretKey, byte[])}.
+     *
+     * @param keyBytes the key bytes.
+     * @return the secret key. The returned key can be {@linkplain Destroyable#destroy() destroyed} when no longer
+     * required.
+     */
+    public static SecretKey authKey(ByteSlice keyBytes) {
+        return authKey(keyBytes.toByteArray());
     }
 
     /**

--- a/src/main/java/software/pando/crypto/nacl/Crypto.java
+++ b/src/main/java/software/pando/crypto/nacl/Crypto.java
@@ -22,6 +22,9 @@ import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.Arrays;
+import java.util.Iterator;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * The main interface to all cryptographic operations provided by this library.
@@ -134,6 +137,108 @@ public final class Crypto {
     }
 
     /**
+     * Authenticates one or more message blocks and returns a 32-byte authentication tag that can be used with
+     * {@link #authVerifyMulti(SecretKey, Iterable, byte[])} to ensure the blocks have not been forged or tampered with.
+     * Each block is individually authenticated, independent of any other blocks. For example, the two blocks
+     * {@code ["foo", "bar"]} will produce a different authentication tag to the two blocks {@code ["fo", "obar"]}, and
+     * to the two blocks {@code ["bar", "foo"]}, or any other combination. Only the exact same sequence of blocks, in
+     * the same order, will produce the same authentication tag for a given key.
+     *
+     * <p>The algorithm used is as follows:
+     * <ol>
+     *     <li>First, two 256-bit sub-keys, {@code macKey} and {@code finKey}, are derived from the input key using
+     *     {@link #kdfDeriveFromKey(SecretKey, byte[], int)} with the ASCII bytes of the string
+     *     {@code "AuthMulti-HMAC-SHA-512-256"} as the context.</li>
+     *     <li>The blocks are then processed in a <a href="https://cseweb.ucsd.edu/~mihir/papers/cascade.pdf"
+     *     ><em>cascade</em></a> construction using the macKey, as in the following
+     *     pseudocode:
+     *     <pre>{@code
+     *         require blocks.size() > 0
+     *         var tag = null
+     *         for block in blocks:
+     *             tag = auth(macKey, block)
+     *             macKey = authKey(tag)
+     *         end
+     *     }</pre>
+     *     </li>
+     *     <li>The tag is then finalized by applying {@code tag = auth(finKey, tag)} using the separate finalization
+     *     key, to prevent <a href="https://en.wikipedia.org/wiki/Length_extension_attack">length extension
+     *     attacks</a>.</li>
+     * </ol>
+     *
+     * <p><strong>Warning:</strong> a given key should either be used for {@link #auth(SecretKey, byte[])} <em>or</em>
+     * for this method, never for both.
+     *
+     * <p>Note: if the {@code authKey} argument is stored in a Hardware Security Module or other secure hardware
+     * solution, be aware that this method derives key-equivalent material that is kept in-memory, outside of the
+     * protection of the secure hardware. If hardware security protection is essential to your use-case, then consider
+     * using an alternative method, such as combining the data blocks into some unambiguous encoding and passing the
+     * entire encoded data as one argument to {@link #auth(SecretKey, byte[])} instead.
+     *
+     * <p>The implementation is guaranteed to call {@link Iterable#iterator()} at most once on the argument.
+     *
+     * @param authKey the authentication key. See {@link #authKeyGen()}.
+     * @param blocks the blocks of data to be authenticated.
+     * @return the 32-byte authentication tag.
+     * @throws IllegalArgumentException if either input argument is {@code null} or there is not at least one data
+     * block provided.
+     */
+    public static byte[] authMulti(SecretKey authKey, Iterable<byte[]> blocks) {
+        Iterator<byte[]> iterator;
+        if (blocks == null || !(iterator = blocks.iterator()).hasNext()) {
+            throw new IllegalArgumentException("Must supply at least one data block to authenticate");
+        }
+        var context = "AuthMulti-HMAC-SHA-512-256".getBytes(US_ASCII);
+        var subKeys = kdfDeriveFromKey(authKey, context, 64);
+        var macKey = (CryptoSecretKey) authKey(ByteSlice.ofRange(subKeys, 0, 32));
+        var finKey = (CryptoSecretKey) authKey(ByteSlice.ofRange(subKeys, 32, 64));
+
+        try {
+            byte[] tag = new byte[0];
+            while (iterator.hasNext()) {
+                var block = iterator.next();
+                if (block == null) {
+                    throw new IllegalArgumentException("Null data block");
+                }
+                Arrays.fill(tag, (byte) 0);
+                tag = auth(macKey, block);
+                macKey = (CryptoSecretKey) authKey(tag);
+            }
+            tag = auth(finKey, tag);
+            return tag;
+        } finally {
+            macKey.destroy();
+            finKey.destroy();
+        }
+    }
+
+    /**
+     * Verifies an authenticate tag previously computed over a list of data blocks by
+     * {@link #authMulti(SecretKey, Iterable)}. If any block has been altered, or a block added, removed, or rearranged
+     * then the authentication will fail (returning {@code false}).
+     *
+     * @param authKey the authentication key. See {@link #authKeyGen()}.
+     * @param blocks the blocks of data to be authenticated.
+     * @param expectedTag the authentication tag previously computed by a call to
+     * {@link #authMulti(SecretKey, Iterable)}.
+     * @return {@code true} if the computed authentication tag matches the expected one (with the comparison performed
+     * in constant time), otherwise {@code false}.
+     * @throws IllegalArgumentException if any of the arguments is {@code null}, or if there is not at least one
+     * block in the blocks iterable.
+     */
+    public static boolean authVerifyMulti(SecretKey authKey, Iterable<byte[]> blocks, byte[] expectedTag) {
+        if (expectedTag == null) {
+            throw new IllegalArgumentException("Invalid tag");
+        }
+        byte[] computedTag = authMulti(authKey, blocks);
+        try {
+            return Bytes.equal(computedTag, expectedTag);
+        } finally {
+            Arrays.fill(computedTag, (byte) 0);
+        }
+    }
+
+    /**
      * Generates a random signing key pair for use with {@link #sign(PrivateKey, byte[])} and
      * {@link #signVerify(PublicKey, byte[], byte[])}. Use {@link PrivateKey#destroy()} when you are finished with
      * the private key to destroy the key material.
@@ -214,5 +319,80 @@ public final class Crypto {
             throw new IllegalArgumentException("invalid Ed25519 public key");
         }
         return Ed25519.verify(data, signature, ((Ed25519.PublicKey) publicKey).getKeyBytes());
+    }
+
+    /**
+     * Generates a fresh random secret key that can be used to generate one or more other keys via
+     * {@link #kdfDeriveFromKey(SecretKey, byte[], int)}.
+     *
+     * @return a fresh random HKDF root key. The returned key can be {@linkplain Destroyable#destroy() destroyed} when
+     * no longer required.
+     */
+    public static SecretKey kdfKeyGen() {
+        return authKeyGen();
+    }
+
+    /**
+     * Derives one or more sub-keys from a single high-quality root key. Up to 16,320 bytes of key material can be
+     * derived using this method. This method is <em>not suitable</em> for deriving keys from a password or other
+     * low-entropy input.
+     *
+     * <p>If deriving multiple keys from the same input key material it is recommended to either derive all the required
+     * key material in one call, or else to ensure that the context argument is different on each call. Otherwise,
+     * identical keys will be generated.
+     *
+     * <p>If the rootKey is stored in a Hardware Security Module or other secure cryptographic module, be aware that the
+     * output key material is exposed in-memory, outside of the confines of the secure processor. In this case, it is
+     * recommended that the context argument be as specific as possible, ideally including a per-invocation random
+     * component (such as a message ID) so that compromise of the output key material doesn't allow an attacker to
+     * bypass the HSM entirely.
+     *
+     * <p><strong>Warning:</strong> the root key should only be used to derive other keys, and not also used directly
+     * for {@link #auth(SecretKey, byte[])} or for other algorithms. Doing so may allow an attacker to recover key
+     * material by crafting carefully chosen messages for you to authenticate.
+     *
+     * <p>The current implementation uses <a href="https://www.rfc-editor.org/rfc/rfc5869">HKDF</a>
+     * instantiated with HMAC-SHA-512.
+     *
+     * @param rootKey the high entropy root key to derive further sub-keys from.
+     * @param context the context in which the key is being used. This context argument should typically encode
+     *                protocol or application identifiers, identifiers of parties involved in a cryptographic
+     *                transaction, and public key material or certificates of those parties.
+     * @param outputKeySizeBytes the total number of bytes of output, up to 16,320 bytes.
+     * @return the requested key material derived from the root key and context.
+     */
+    public static byte[] kdfDeriveFromKey(SecretKey rootKey, byte[] context, int outputKeySizeBytes) {
+        return HKDF.HKDF_HMAC_SHA512.expand(rootKey, context, outputKeySizeBytes);
+    }
+
+    /**
+     * Derives one or more sub-keys from some high-entropy, but not necessarily uniformly random, input key material.
+     * Up to 16,320 bytes of key material can be derived using this method. This method is <em>not suitable</em> for
+     * deriving keys from a password or other low-entropy input.
+     *
+     * <p>The current implementation uses <a href="https://www.rfc-editor.org/rfc/rfc5869">HKDF</a>
+     * instantiated with HMAC-SHA-512.
+     *
+     * @param inputKeyMaterial the high entropy key material to derive further sub-keys from, such as the output from
+     *               {@link Subtle#scalarMultiplication(PrivateKey, PublicKey)}.
+     * @param salt an optional uniformly random salt value to improve entropy extraction from the input key material.
+     *            This value should ideally be of high entropy, and should never be attacker-controlled. The value
+     *             can be fixed and public and even a low-entropy value provides some value in terms of domain
+     *             separation.
+     * @param context the context in which the key is being used. This context argument should typically encode
+     *                protocol or application identifiers, identifiers of parties involved in a cryptographic
+     *                transaction, and public key material or certificates of those parties.
+     * @param outputKeySizeBytes the total number of bytes of output, up to 16,320 bytes.
+     * @return the requested key material derived from the root key and context.
+     */
+    public static byte[] kdfDeriveFromInputKeyMaterial(byte[] salt, byte[] inputKeyMaterial, byte[] context,
+            int outputKeySizeBytes) {
+        try (var prk = HKDF.HKDF_HMAC_SHA512.extract(salt, inputKeyMaterial)) {
+            return kdfDeriveFromKey(prk, context, outputKeySizeBytes);
+        }
+    }
+
+    private Crypto() {
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/software/pando/crypto/nacl/CryptoSecretKey.java
+++ b/src/main/java/software/pando/crypto/nacl/CryptoSecretKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Neil Madden.
+ * Copyright 2019-2022 Neil Madden.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,46 +16,136 @@
 
 package software.pando.crypto.nacl;
 
-import java.util.Arrays;
-
 import javax.crypto.SecretKey;
+import javax.security.auth.Destroyable;
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Locale;
 
-final class CryptoSecretKey implements SecretKey {
+/**
+ * An alternative to {@link javax.crypto.spec.SecretKeySpec} that actually implements the {@link Destroyable#destroy()}
+ * method by wiping data from memory. This is a best-effort attempt to wipe data, because the JVM may have copied the
+ * key material during garbage collection, or it may have been swapped to disk, etc. In future this class may include
+ * other measures, such as using off-heap memory (direct byte buffer) or obfuscation to protect key material.
+ * <p>
+ * Because Java APIs use mutable byte arrays (and not say, immutable byte slices), this class performs defensive copying
+ * of the key material during construction and for {@link #getEncoded()} calls. The caller should take care to wipe
+ * those byte arrays after use. The APIs within Salty Coffee take care to always wipe these temporary arrays, but the
+ * Java Cryptography API typically doesn't.
+ * <p>
+ * This class maintains some limited compatibility with {@link javax.crypto.spec.SecretKeySpec}. In particular, the
+ * {@link #equals(Object)} method is compatible: equivalent keys will be seen as equal. However, {@link #hashCode()} is
+ * not equivalent because the SecretKeySpec implementation leaks information about the key material.
+ */
+final class CryptoSecretKey implements SecretKey, AutoCloseable {
+    private static final long serialVersionUID = 1L;
 
     private final byte[] keyMaterial;
     private final String algorithm;
+    private final int hashCode;
+
+    private volatile boolean destroyed = false;
+
+    CryptoSecretKey(byte[] keyMaterial, int offset, int length, String algorithm) {
+        this.keyMaterial = Arrays.copyOfRange(keyMaterial, offset, offset + length);
+        this.algorithm = algorithm;
+        this.hashCode = Arrays.hashCode(Crypto.hash(this.keyMaterial)) ^ algorithm.toLowerCase(Locale.ROOT).hashCode();
+    }
 
     CryptoSecretKey(byte[] keyMaterial, String algorithm) {
-        this.keyMaterial = keyMaterial.clone();
-        this.algorithm = algorithm;
+        this(keyMaterial, 0, keyMaterial.length, algorithm);
     }
 
     @Override
     public String getAlgorithm() {
+        checkDestroyed();
         return algorithm;
     }
 
     @Override
     public String getFormat() {
+        checkDestroyed();
         return "RAW";
     }
 
     @Override
     public byte[] getEncoded() {
+        checkDestroyed();
         return keyMaterial.clone();
     }
 
     @Override
     public void destroy() {
-        Arrays.fill(keyMaterial, (byte) 0);
+        if (!destroyed) {
+            destroyed = true;
+            Arrays.fill(keyMaterial, (byte) 0);
+        }
     }
 
     @Override
     public boolean isDestroyed() {
-        int x = 0;
-        for (byte b : keyMaterial) {
-            x |= b;
+        return destroyed;
+    }
+
+    @Override
+    public void close() {
+        destroy();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        checkDestroyed();
+        if (this == other) {
+            return true;
         }
-        return x == 0;
+        if (!(other instanceof SecretKey)) {
+            return false;
+        }
+        var that = (SecretKey) other;
+
+        if (!"RAW".equalsIgnoreCase(that.getFormat())) {
+            return false;
+        }
+
+        var encoded = that instanceof CryptoSecretKey ? ((CryptoSecretKey) that).keyMaterial : that.getEncoded();
+        try {
+            return algorithm.equalsIgnoreCase(that.getAlgorithm()) && MessageDigest.isEqual(keyMaterial, encoded);
+        } finally {
+            if (!(that instanceof CryptoSecretKey)) {
+                Arrays.fill(encoded, (byte) 0);
+            }
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        checkDestroyed();
+        return hashCode;
+    }
+
+    @Override
+    public String toString() {
+        return "CryptoSecretKey{" +
+                "algorithm='" + algorithm + "', " +
+                "destroyed=" + isDestroyed() + ", " +
+                "keySize=" + keyMaterial.length * 8 + " bits" +
+                '}';
+    }
+
+    private void checkDestroyed() {
+        if (destroyed) {
+            throw new IllegalStateException("Key has been destroyed");
+        }
+    }
+
+    // The SecretKey interface extends Serializable. Java serialization is inherently insecure, so we override these
+    // methods to prevent it.
+    private void readObject(java.io.ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        throw new NotSerializableException(getClass().getName());
+    }
+    private void writeObject(java.io.ObjectOutputStream stream) throws IOException {
+        throw new NotSerializableException(getClass().getName());
     }
 }

--- a/src/main/java/software/pando/crypto/nacl/Ed25519.java
+++ b/src/main/java/software/pando/crypto/nacl/Ed25519.java
@@ -1617,6 +1617,8 @@ final class Ed25519 {
         }
     }
 
+    private Ed25519() {}
+
     static class PrivateKey implements java.security.PrivateKey {
 
         private final byte[] keyBytes;

--- a/src/main/java/software/pando/crypto/nacl/Ed25519Constants.java
+++ b/src/main/java/software/pando/crypto/nacl/Ed25519Constants.java
@@ -126,4 +126,6 @@ final class Ed25519Constants {
             bi = edwards(bi, b2);
         }
     }
+
+    private Ed25519Constants() {}
 }

--- a/src/main/java/software/pando/crypto/nacl/Field25519.java
+++ b/src/main/java/software/pando/crypto/nacl/Field25519.java
@@ -588,4 +588,6 @@ final class Field25519 {
         // a >= 0 iff a >= b.
         return ~(a >> 31);
     }
+
+    private Field25519() {}
 }

--- a/src/main/java/software/pando/crypto/nacl/HKDF.java
+++ b/src/main/java/software/pando/crypto/nacl/HKDF.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 Neil Madden.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.pando.crypto.nacl;
+
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Implementation of the
+ * <a href="https://www.rfc-editor.org/rfc/rfc5869">HMAC-based Extract-and-Expand Key Derivation function (HKDF).</a>
+ */
+final class HKDF {
+    static final HKDF HKDF_HMAC_SHA512 = new HKDF(SHA512.MAC_ALGORITHM);
+
+    private final int saltLenBytes;
+    private final int tagLenBytes;
+    private final String hmacAlgorithm;
+
+    HKDF(String hmacAlgorithm) {
+        try {
+            this.hmacAlgorithm = Objects.requireNonNull(hmacAlgorithm);
+            var mac = Mac.getInstance(hmacAlgorithm);
+            this.saltLenBytes = mac.getMacLength();
+            this.tagLenBytes = mac.getMacLength();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Extracts a pseudorandom key (PRK) from some input key material, which is high entropy but potentially not a
+     * uniform random bit string.
+     *
+     * @param salt an optional random salt parameter to improve the entropy extraction process, or at least provide
+     *             domain separation when the same input key material is used for different applications. Ideally
+     *             this should be a uniform random bit string, but it can be public and fixed for a given application.
+     * @param inputKeyMaterial the input key material.
+     * @return a high quality pseudorandom key that is suitable for use with {@link #expand(SecretKey, byte[], int)}
+     * to derive further keys.
+     */
+    CryptoSecretKey extract(byte[] salt, byte[] inputKeyMaterial) {
+        if (salt == null || salt.length == 0) {
+            salt = new byte[saltLenBytes];
+        }
+        try (var saltAsKey = hmacKey(salt)) {
+            return hmacKey(hmac(saltAsKey, inputKeyMaterial));
+        }
+    }
+
+    /**
+     * Expands a single high-quality key into a pseudorandom key stream suitable for use as cryptographic keys. The
+     * derived key material is bound to the given context, ensuring that keys derived for different contexts are
+     * independent of each other.
+     *
+     * @param prk the single key to derive multiple keys from.
+     * @param context the context in which the key is being used. This context argument should typically encode
+     *                protocol or application identifiers, identifiers of parties involved in a cryptographic
+     *                transaction, and public key material or certificates of those parties.
+     * @param outputKeySizeBytes the size of key material to generate, in bytes. This has a maximum of 8,160 bytes.
+     * @return the derived output key material.
+     */
+    byte[] expand(SecretKey prk, byte[] context, int outputKeySizeBytes) {
+        if (outputKeySizeBytes <= 0 || outputKeySizeBytes > 255 * tagLenBytes) {
+            throw new IllegalArgumentException("Output size must be >= 1 and <= " + 255 * tagLenBytes);
+        }
+        byte[] last = new byte[0];
+        byte[] counter = new byte[1];
+        byte[] output = new byte[outputKeySizeBytes];
+        for (int i = 0; i < outputKeySizeBytes; i += tagLenBytes) {
+            counter[0]++;
+            last = hmac(prk, Bytes.concat(last, context, counter));
+            System.arraycopy(last, 0, output, i, Math.min(outputKeySizeBytes - i, tagLenBytes));
+        }
+        return output;
+    }
+
+    private byte[] hmac(SecretKey key, byte[] data) {
+        try {
+            var mac = Mac.getInstance(hmacAlgorithm);
+            mac.init(key);
+            return mac.doFinal(data);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        } catch (InvalidKeyException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private CryptoSecretKey hmacKey(byte[] keyMaterial) {
+        try {
+            return new CryptoSecretKey(keyMaterial, hmacAlgorithm);
+        } finally {
+            Arrays.fill(keyMaterial, (byte) 0);
+        }
+    }
+}

--- a/src/main/java/software/pando/crypto/nacl/Salsa20.java
+++ b/src/main/java/software/pando/crypto/nacl/Salsa20.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Neil Madden.
+ * Copyright 2019-2022 Neil Madden.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/software/pando/crypto/nacl/Salsa20.java
+++ b/src/main/java/software/pando/crypto/nacl/Salsa20.java
@@ -21,6 +21,7 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 
 final class Salsa20 {
+    static final int BLOCK_SIZE = 64;
     private static final int STATE_LEN = 16;
 
     static void quarterRound(int[] state, int a, int b, int c, int d) {
@@ -63,8 +64,13 @@ final class Salsa20 {
     }
 
     static void encrypt(byte[] key, byte[] nonce, byte[] plaintext) {
+        encrypt(key, nonce, ByteSlice.of(plaintext, 0, plaintext.length), ByteSlice.of(plaintext, 0));
+    }
+
+    static void encrypt(byte[] key, byte[] nonce, ByteSlice plaintext, ByteSlice ciphertext) {
         assert key.length == 32;
         assert nonce.length >= 8;
+        assert ciphertext.length >= plaintext.length;
 
         if (nonce.length < 16) {
             byte[] newNonce = new byte[16];
@@ -75,18 +81,29 @@ final class Salsa20 {
         int[] state = initialState(key, nonce);
 
         int numBlocks = (plaintext.length + 63) >>> 6;
+        long initialCounter = state[8] & 0xFFFFFFFFL | (state[9] & 0xFFFFFFFFL) << 32;
+        if (initialCounter < 0L || initialCounter + numBlocks < 0L) {
+            throw new IllegalArgumentException("Block counter exceeds size of 64-bit signed long");
+        }
         for (int block = 0; block < numBlocks; ++block) {
-            state[8] = block;
+            long newCounter = initialCounter + block;
+            state[8] = (int) newCounter;
+            state[9] = (int) (newCounter >>> 32);
 
             byte[] keystream = bytes(blockFunction(state));
 
             int start = block * 64;
             int end = Math.min(start + 64, plaintext.length);
             for (int i = start; i < end; ++i) {
-                plaintext[i] ^= keystream[i - start];
+                ciphertext.array[ciphertext.offset + i] =
+                        (byte) (plaintext.array[plaintext.offset + i] ^ keystream[i - start]);
             }
             Arrays.fill(keystream, (byte) 0);
         }
+    }
+
+    static void decrypt(byte[] key, byte[] nonce, ByteSlice ciphertext, ByteSlice plaintext) {
+        encrypt(key, nonce, ciphertext, plaintext);
     }
 
     static void decrypt(byte[] key, byte[] nonce, byte[] ciphertext) {

--- a/src/main/java/software/pando/crypto/nacl/Subtle.java
+++ b/src/main/java/software/pando/crypto/nacl/Subtle.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2022 Neil Madden.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.pando.crypto.nacl;
+
+import javax.crypto.SecretKey;
+import javax.security.auth.Destroyable;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Arrays;
+
+/**
+ * Cryptographic utilities and building blocks from which more complex requirements can be built, but which have
+ * <strong>subtle security properties and dangerous edge-cases if misused.</strong> Unless you have significant
+ * experience in the design of cryptographic protocols, you are strongly advised to only use the APIs in {@link Crypto}.
+ * These utility methods are provided for advanced users and for compatibility with existing protocols and applications.
+ */
+public final class Subtle {
+    /**
+     * The size (in bytes) of keys used by {@link #streamXSalsa20Key(ByteSlice)}.
+     */
+    public static final int XSALSA20_KEY_SIZE = XSalsa20.KEY_SIZE;
+    /**
+     * The size (in bytes) of nonce expected by {@link #streamXSalsa20(SecretKey, byte[])}.
+     */
+    public static final int XSALSA20_NONCE_SIZE = XSalsa20.NONCE_LEN;
+
+    /**
+     * Performs a raw X25519 key agreement between the given private key (scalar) and the given public key (curve
+     * point). The result is the raw output of the X25519 function, which hasn't been hashed or passed through a key
+     * derivation function (KDF), so <strong>should not be directly used as a cryptographic key.</strong>
+     *
+     * @param privateKey the private key (scalar).
+     * @param publicKey the public point to multiply by the scalar, as if through repeated point addition.
+     * @return the u-coordinate output of the X25519 function applied to the given arguments.
+     */
+    public static byte[] scalarMultiplication(PrivateKey privateKey, PublicKey publicKey) {
+        return CryptoBox.scalarMultiplication(privateKey, publicKey);
+    }
+
+    /**
+     * Performs a raw X25519 key agreement between the given private key (scalar) and the given public key (curve
+     * point). The result is the raw output of the X25519 function, which hasn't been hashed or passed through a key
+     * derivation function (KDF), so <strong>should not be directly used as a cryptographic key.</strong>
+     *
+     * @param scalar the private scalar.
+     * @param point the public point to multiply by the scalar, as if through repeated point addition.
+     * @return the u-coordinate output of the X25519 function applied to the given arguments.
+     */
+    public static byte[] scalarMultiplication(byte[] scalar, byte[] point) {
+        return CryptoBox.scalarMultiplication(CryptoBox.privateKey(scalar), CryptoBox.publicKey(point));
+    }
+
+    /**
+     * Imports the given key bytes into a key object for use with {@link #streamXSalsa20(SecretKey)}. The byte slice is
+     * wiped after the key is constructed.
+     *
+     * @param keyBytes the key bytes
+     * @return the secret key. The returned key can be {@linkplain Destroyable#destroy() destroyed} when no longer
+     * required.
+     */
+    public static SecretKey streamXSalsa20Key(ByteSlice keyBytes) {
+        if (keyBytes == null || keyBytes.length != XSalsa20.KEY_SIZE) {
+            throw new IllegalArgumentException("Key must be " + XSalsa20.KEY_SIZE + " bytes");
+        }
+        try {
+            return new CryptoSecretKey(keyBytes.toByteArray(), XSalsa20.ALGORITHM);
+        } finally {
+            keyBytes.wipe();
+        }
+    }
+
+    /**
+     * Imports the given key bytes into a key object for use with {@link #streamXSalsa20(SecretKey)}. The byte array is
+     * wiped after the key is constructed, use {@code keyBytes.clone()} if you need to retain a copy.
+     *
+     * @param keyBytes the key bytes
+     * @return the secret key. The returned key can be {@linkplain Destroyable#destroy() destroyed} when no longer
+     * required.
+     */
+    public static SecretKey streamXSalsa20Key(byte[] keyBytes) {
+        return streamXSalsa20Key(ByteSlice.of(keyBytes));
+    }
+
+    /**
+     * Generates a fresh random key for use with {@link #streamXSalsa20(SecretKey)}.
+     *
+     * @return the secret key. The returned key can be {@linkplain Destroyable#destroy() destroyed} when no longer
+     * required.
+     */
+    public static SecretKey streamXSalsa20KeyGen() {
+        return streamXSalsa20Key(Bytes.secureRandom(XSalsa20.KEY_SIZE));
+    }
+
+    /**
+     * Constructs and returns a low-level XSalsa20 stream cipher object that can be used to encrypt or decrypt an
+     * effectively unlimited amount of data <em>without any integrity protection</em>.
+     *
+     * <p>XSalsa20 is an <em>unauthenticated</em> stream cipher, allowing an attacker to arbitrarily modify ciphertext
+     * and potentially recover plaintext through chosen ciphertext attacks. It is highly recommended to use
+     * {@link SecretBox} instead unless you really know what you are doing.
+     *
+     * <p>This version requires an explicit 24-byte nonce, which <strong>must be unique</strong> for each message
+     * encrypted with the same key. Repeating a nonce results in almost total loss of security. It is recommended to use
+     * {@link #streamXSalsa20(SecretKey)} for encryption to automatically generate a random nonce.
+     *
+     * @param key the key to use for encryption/decryption, created by {@link #streamXSalsa20Key(ByteSlice)}.
+     * @param nonce the 24-byte unique nonce to use. This <strong>MUST</strong> be unique for each message encrypted
+     *              with the same key. For decryption the nonce used during encryption must be provided.
+     * @return the stream cipher object.
+     */
+    public static StreamCipher streamXSalsa20(SecretKey key, byte[] nonce) {
+        if (!XSalsa20.ALGORITHM.equals(key.getAlgorithm())) {
+            throw new IllegalArgumentException("Invalid key");
+        }
+        var keyBytes = key.getEncoded();
+        if (keyBytes.length != XSalsa20.KEY_SIZE) {
+            throw new IllegalArgumentException("Invalid key");
+        }
+        if (nonce == null || nonce.length != XSalsa20.NONCE_LEN) {
+            throw new IllegalArgumentException("Invalid nonce");
+        }
+        return new XSalsa20StreamCipher(keyBytes, nonce, 0L);
+    }
+
+    /**
+     * Constructs and returns a low-level XSalsa20 stream cipher object that can be used to encrypt or decrypt an
+     * effectively unlimited amount of data <em>without any integrity protection</em>.
+     *
+     * <p>XSalsa20 is an <em>unauthenticated</em> stream cipher, allowing an attacker to arbitrarily modify ciphertext
+     * and potentially recover plaintext through chosen ciphertext attacks. It is highly recommended to use
+     * {@link SecretBox} instead unless you really know what you are doing.
+     *
+     * <p>This version generates a random 24-byte nonce and initializes the initial block counter to 0.
+     *
+     * @param key the key to use for encryption/decryption, created by {@link #streamXSalsa20Key(ByteSlice)}.
+     * @return the stream cipher object.
+     */
+    public static StreamCipher streamXSalsa20(SecretKey key) {
+        var nonce = Bytes.secureRandom(XSalsa20.NONCE_LEN);
+        return streamXSalsa20(key, nonce);
+    }
+
+    private Subtle() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * An <em>unauthenticated</em> low-level stream cipher object that can be used to encrypt or decrypt large amounts
+     * of data. See {@link #streamXSalsa20(SecretKey)} for details and warnings.
+     */
+    public interface StreamCipher extends AutoCloseable {
+
+        /**
+         * Processes the given input slice, storing the output in the specified output slice. For encryption, the input
+         * slice should be the plaintext to be encrypted and the ciphertext will be stored in the given output slice.
+         * For decryption, the input should be the ciphertext and the plaintext will be stored in the output slice.
+         * The output slice must be at least as large as the input slice. The two slices can refer to the same
+         * underlying byte array to allow in-place encryption or decryption, but they should not be overlapping (but
+         * not identical) ranges of the same bytes.
+         *
+         * @param input the input byte slice.
+         * @param output the output byte slice.
+         * @return an updated stream cipher object to process further inputs.
+         */
+        StreamCipher process(ByteSlice input, ByteSlice output);
+
+        /**
+         * Processes the given data in-place, overwriting the slice with the output. This is equivalent to calling
+         * {@link #process(ByteSlice, ByteSlice)} with the same byte slice for both arguments.
+         *
+         * @param inputAndOutput the data to encrypt or decrypt in-place.
+         * @return an updated stream cipher object to process further inputs.
+         */
+        default StreamCipher process(ByteSlice inputAndOutput) {
+            return process(inputAndOutput, inputAndOutput);
+        }
+
+        /**
+         * Provides access to the unique nonce that was used to initialize the stream cipher. If the nonce was generated
+         * randomly (such as by {@link #streamXSalsa20(SecretKey)}, then it can be retrieved using this method. The
+         * nonce should be stored alongside the encrypted message and passed to
+         * {@link #streamXSalsa20(SecretKey, byte[])} for decryption. Typically the nonce is simply prepended to the
+         * ciphertext. The nonce does not need to be kept secret, but if you are building an authenticated encryption
+         * mode from this raw stream cipher then you should ensure that the nonce is included in the
+         * {@linkplain Crypto#auth(SecretKey, byte[]) authenticated data}. The nonce returned by this method is fixed
+         * size. For XSalsa20, the nonce is {@value XSALSA20_NONCE_SIZE}.
+         *
+         * @return a copy of the nonce.
+         */
+        byte[] nonce();
+
+        /**
+         * Indicates that all processing with this stream cipher object is now complete. Any key material will be
+         * wiped from memory and further calls to {@link #process(ByteSlice, ByteSlice)} will result in an exception.
+         * Wiping key material from memory is performed on a best-effort basis, because the JVM garbage collector may
+         * have copied the data.
+         */
+        @Override
+        void close();
+    }
+
+    private static class XSalsa20StreamCipher implements StreamCipher {
+        private final byte[] key;
+        private final byte[] nonce;
+        private long blockCounter;
+        private volatile boolean closed = false;
+
+        XSalsa20StreamCipher(byte[] key, byte[] nonce, long blockCounter) {
+            this.key = key;
+            this.nonce = nonce;
+            this.blockCounter = blockCounter;
+        }
+
+        @Override
+        public StreamCipher process(ByteSlice input, ByteSlice output) {
+            if (closed) {
+                throw new IllegalStateException("Stream cipher has been closed");
+            }
+            blockCounter = XSalsa20.encrypt(key, nonce, blockCounter, input, output);
+            return this;
+        }
+
+        @Override
+        public byte[] nonce() {
+            return nonce.clone();
+        }
+
+        @Override
+        public void close() {
+            if (!closed) {
+                closed = true;
+                Arrays.fill(key, (byte) 0);
+            }
+        }
+    }
+}

--- a/src/main/java/software/pando/crypto/nacl/XSalsa20.java
+++ b/src/main/java/software/pando/crypto/nacl/XSalsa20.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Neil Madden.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.pando.crypto.nacl;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+final class XSalsa20 {
+    static final String ALGORITHM = "XSalsa20";
+    static final int KEY_SIZE = XSalsa20Poly1305.KEY_SIZE;
+    static final int NONCE_LEN = XSalsa20Poly1305.NONCE_LEN;
+
+    static void encrypt(byte[] key, byte[] nonce, byte[] plaintext) {
+        encrypt(key, nonce, 0, ByteSlice.of(plaintext), ByteSlice.of(plaintext));
+    }
+
+    static long encrypt(byte[] key, byte[] nonce, long blockCounter, ByteSlice plaintext, ByteSlice ciphertext) {
+        assert key.length == KEY_SIZE;
+        assert nonce.length == NONCE_LEN;
+
+        byte[] subKey = HSalsa20.apply(key, nonce);
+        try {
+            byte[] subNonce = new byte[16];
+            System.arraycopy(nonce, 16, subNonce, 0, 8);
+            if (blockCounter != 0) {
+                ByteBuffer.wrap(subNonce).order(ByteOrder.LITTLE_ENDIAN).asLongBuffer().put(1, blockCounter);
+            }
+
+            Salsa20.encrypt(subKey, subNonce, plaintext, ciphertext);
+            return blockCounter + (plaintext.length + Salsa20.BLOCK_SIZE - 1) / Salsa20.BLOCK_SIZE;
+        } finally {
+            Arrays.fill(subKey, (byte) 0);
+        }
+    }
+
+    static void decrypt(byte[] key, byte[] nonce, int blockCounter, ByteSlice ciphertext, ByteSlice plaintext) {
+        encrypt(key, nonce, blockCounter, ciphertext, plaintext);
+    }
+
+    static void decrypt(byte[] key, byte[] nonce, byte[] ciphertext) {
+        encrypt(key, nonce, ciphertext);
+    }
+}

--- a/src/test/java/software/pando/crypto/nacl/ByteSliceTest.java
+++ b/src/test/java/software/pando/crypto/nacl/ByteSliceTest.java
@@ -53,4 +53,12 @@ public class ByteSliceTest {
         assertThat(slice.toByteArray()).containsExactly(43, 44);
         assertThat(slice.length()).isEqualTo(2);
     }
+
+    @Test
+    public void shouldWipeCorrectSliceOfArray() {
+        var array = new byte[]{ 42, 43, 44, 45, 46 };
+        var slice = ByteSlice.ofRange(array, 1, 3);
+        slice.wipe();
+        assertThat(array).containsExactly(42, 0, 0, 45, 46);
+    }
 }

--- a/src/test/java/software/pando/crypto/nacl/ByteSliceTest.java
+++ b/src/test/java/software/pando/crypto/nacl/ByteSliceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Neil Madden.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.pando.crypto.nacl;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ByteSliceTest {
+
+    @Test
+    public void shouldCaptureEntireArrayIfSpecified() {
+        var array = new byte[]{ 42, 43, 44 };
+        var slice = ByteSlice.of(array);
+        assertThat(slice.toByteArray()).isEqualTo(array);
+        assertThat(slice.length()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldCaptureRestOfArray() {
+        var array = new byte[]{ 42, 43, 44, 45, 46 };
+        var slice = ByteSlice.of(array, 2);
+        assertThat(slice.toByteArray()).containsExactly(44, 45, 46);
+        assertThat(slice.length()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldCaptureGivenSliceOfArray() {
+        var array = new byte[]{ 42, 43, 44, 45, 46 };
+        var slice = ByteSlice.of(array, 1, 3);
+        assertThat(slice.toByteArray()).containsExactly(43, 44, 45);
+        assertThat(slice.length()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldCaptureGivenRangeOfArray() {
+        var array = new byte[]{ 42, 43, 44, 45, 46 };
+        var slice = ByteSlice.ofRange(array, 1, 3);
+        assertThat(slice.toByteArray()).containsExactly(43, 44);
+        assertThat(slice.length()).isEqualTo(2);
+    }
+}

--- a/src/test/java/software/pando/crypto/nacl/BytesTest.java
+++ b/src/test/java/software/pando/crypto/nacl/BytesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Neil Madden.
+ * Copyright 2019-2022 Neil Madden.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,5 +79,40 @@ public class BytesTest {
         for (int i = 0; i < 1000; ++i) {
             assertThat(Bytes.secureRandom(i)).hasSize(i);
         }
+    }
+
+    @DataProvider
+    public Object[][] concat2ArgCases() {
+        return new Object[][] {
+                {new byte[0], new byte[0], new byte[0]},
+                {new byte[]{42}, new byte[0], new byte[]{42}},
+                {new byte[0], new byte[]{42}, new byte[]{42}},
+                {new byte[]{42}, new byte[]{43}, new byte[]{42, 43}},
+                {new byte[]{1,2,3}, new byte[]{4,5,6}, new byte[]{1,2,3,4,5,6}}
+        };
+    }
+
+    @Test(dataProvider = "concat2ArgCases")
+    public void shouldConcatenate2ByteArraysCorrectly(byte[] a, byte[] b, byte[] concat) {
+        assertThat(Bytes.concat(a, b)).isEqualTo(concat);
+    }
+
+    @DataProvider
+    public Object[][] concat3ArgCases() {
+        return new Object[][] {
+                {new byte[0], new byte[0], new byte[0], new byte[0]},
+                {new byte[]{42}, new byte[0], new byte[0], new byte[]{42}},
+                {new byte[0], new byte[]{42}, new byte[0], new byte[]{42}},
+                {new byte[0], new byte[0], new byte[]{42}, new byte[]{42}},
+                {new byte[]{42}, new byte[]{43}, new byte[0], new byte[]{42, 43}},
+                {new byte[]{42}, new byte[0], new byte[]{43}, new byte[]{42, 43}},
+                {new byte[0], new byte[]{42}, new byte[]{43}, new byte[]{42, 43}},
+                {new byte[]{1,2,3}, new byte[]{4,5,6}, new byte[]{7,8,9}, new byte[]{1,2,3,4,5,6,7,8,9}}
+        };
+    }
+
+    @Test(dataProvider = "concat3ArgCases")
+    public void shouldConcatenate3ByteArraysCorrectly(byte[] a, byte[] b, byte[] c, byte[] concat) {
+        assertThat(Bytes.concat(a, b, c)).isEqualTo(concat);
     }
 }

--- a/src/test/java/software/pando/crypto/nacl/CryptoSecretKeyTest.java
+++ b/src/test/java/software/pando/crypto/nacl/CryptoSecretKeyTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2022 Neil Madden.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.pando.crypto.nacl;
+
+import org.testng.annotations.Test;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CryptoSecretKeyTest {
+    private static final byte[] KEY_DATA = new byte[32];
+    static {
+        for (int i = 0; i < KEY_DATA.length; ++i) {
+            KEY_DATA[i] = (byte) i;
+        }
+    }
+
+    @Test
+    public void shouldUseEntireByteArrayIfRangeNotSpecified() {
+        // Given
+        var key = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+
+        // When
+        var keyData = key.getEncoded();
+
+        // Then
+        assertThat(keyData).isEqualTo(KEY_DATA);
+    }
+
+    @Test
+    public void shouldUseSpecifiedRangeOfKeyMaterial() {
+        // Given
+        var key = new CryptoSecretKey(KEY_DATA.clone(), 5, 10, "AES");
+
+        // When
+        var keyData = key.getEncoded();
+
+        // Then
+        assertThat(keyData).isEqualTo(Arrays.copyOfRange(KEY_DATA, 5, 15));
+    }
+
+    @Test
+    public void shouldTakeDefensiveCopyOfInputKeyMaterial() {
+        // Given
+        var originalKeyData = KEY_DATA.clone();
+        var key = new CryptoSecretKey(originalKeyData, "AES");
+
+        // When
+        Arrays.fill(originalKeyData, (byte) 42);
+        var result = key.getEncoded();
+
+        // Then
+        assertThat(result).isNotEqualTo(originalKeyData).isEqualTo(KEY_DATA);
+    }
+
+    @Test
+    public void shouldTakeDefensiveCopyOfOutputKeyMaterial() {
+        // Given
+        var key = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        var encoded = key.getEncoded();
+
+        // When
+        Arrays.fill(encoded, (byte) 42);
+        var result = key.getEncoded();
+
+        // Then
+        assertThat(result).isNotEqualTo(encoded).isEqualTo(KEY_DATA);
+    }
+
+    @Test
+    public void shouldSupportDestroyingKeyMaterial() {
+        // Given
+        var key = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+
+        // When
+        key.destroy();
+
+        // Then
+        assertThat(key.isDestroyed()).isTrue();
+        assertThat(key).extracting("keyMaterial").isEqualTo(new byte[32]);
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void shouldThrowExceptionIfKeyHasBeenDestroyed() {
+        // Given
+        var key = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        key.destroy();
+
+        // When
+        key.getEncoded();
+    }
+
+    @Test
+    public void shouldUseConsistentHashCode() {
+        // Given
+        var key1 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        var key2 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+
+        // When
+        int hashCode1 = key1.hashCode();
+        int hashCode2 = key2.hashCode();
+
+        // Then
+        assertThat(hashCode1).isEqualTo(hashCode2).isEqualTo(1580929082);
+    }
+
+    @Test
+    public void shouldVaryHashCodeBasedOnKeyMaterial() {
+        // Given
+        var key1 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        var alteredKeyData = KEY_DATA.clone();
+        alteredKeyData[0] = 42;
+        var key2 = new CryptoSecretKey(alteredKeyData, "AES");
+
+        // When
+        int hashCode1 = key1.hashCode();
+        int hashCode2 = key2.hashCode();
+
+        // Then
+        assertThat(hashCode1).isNotEqualTo(hashCode2);
+    }
+
+    @Test
+    public void shouldVaryHashCodeBasedOnKeyAlgorithm() {
+        // Given
+        var key1 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        var key2 = new CryptoSecretKey(KEY_DATA.clone(), "HmacSHA256");
+
+        // When
+        int hashCode1 = key1.hashCode();
+        int hashCode2 = key2.hashCode();
+
+        // Then
+        assertThat(hashCode1).isNotEqualTo(hashCode2);
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void shouldThrowExceptionFromHashCodeIfDestroyed() {
+        // Given
+        var key = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+
+        // When
+        key.destroy();
+        ignore(key.hashCode());
+
+        // Then - exception
+    }
+
+    @Test
+    public void equalsShouldBeReflexive() {
+        var key = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        assertThat(key).isEqualTo(key);
+    }
+
+    @Test
+    public void equalsShouldBeSymmetric() {
+        var key1 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        var key2 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+
+        assertThat(key1).isEqualTo(key2);
+        assertThat(key2).isEqualTo(key1);
+    }
+
+    @Test
+    public void equalsShouldBeTransitive() {
+        var key1 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        var key2 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        var key3 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+
+        assertThat(key1).isEqualTo(key2);
+        assertThat(key2).isEqualTo(key3);
+        assertThat(key1).isEqualTo(key3);
+    }
+
+    @Test
+    public void shouldNotBeEqualToNull() {
+        assertThat(new CryptoSecretKey(KEY_DATA.clone(), "AES")).isNotEqualTo(null);
+    }
+
+    @Test
+    public void shouldNotBeEqualIfAlgorithmIsDifferent() {
+        var key1 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        var key2 = new CryptoSecretKey(KEY_DATA.clone(), "HmacSHA256");
+        assertThat(key1).isNotEqualTo(key2);
+    }
+
+    @Test
+    public void shouldNotBeEqualIfKeyDataIsDifferent() {
+        var key1 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        var alteredKeyData = KEY_DATA.clone();
+        alteredKeyData[0] = 42;
+        var key2 = new CryptoSecretKey(alteredKeyData, "AES");
+        assertThat(key1).isNotEqualTo(key2);
+    }
+
+    @Test
+    public void shouldNotBeEqualIfFormatIsDifferent() {
+        SecretKey key1 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        SecretKey key2 = new SecretKeySpec(KEY_DATA.clone(), "AES") {
+            @Override
+            public String getFormat() {
+                return "special";
+            }
+        };
+        assertThat(key1).isNotEqualTo(key2);
+    }
+
+    @Test
+    public void shouldBeEqualToEquivalentSecretKeySpec() {
+        SecretKey key1 = new CryptoSecretKey(KEY_DATA.clone(), "AES");
+        SecretKey key2 = new SecretKeySpec(KEY_DATA.clone(), "AES");
+        assertThat(key1).isEqualTo(key2);
+    }
+
+    @Test
+    public void shouldReturnSpecifiedKeyAlgorithm() {
+        assertThat(new CryptoSecretKey(KEY_DATA.clone(), "test").getAlgorithm()).isEqualTo("test");
+    }
+
+    @Test
+    public void shouldUseRawKeyFormat() {
+        assertThat(new CryptoSecretKey(KEY_DATA.clone(), "AES").getFormat()).isEqualToIgnoringCase("RAW");
+    }
+
+    private static void ignore(Object ignored) {}
+}

--- a/src/test/java/software/pando/crypto/nacl/HKDFTest.java
+++ b/src/test/java/software/pando/crypto/nacl/HKDFTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2022 Neil Madden.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.pando.crypto.nacl;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.internal.Digests.fromHex;
+
+public class HKDFTest {
+
+    @DataProvider
+    public Object[][] rfc5869TestVectors() {
+        return new Object[][] {
+                {
+                    "SHA-256", // Hash
+                    "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", // IKM
+                    "000102030405060708090a0b0c", // Salt
+                    "f0f1f2f3f4f5f6f7f8f9", // Info
+                    42, // L
+                    "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5", // PRK
+                    "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865" // OKM
+                },
+                {
+                    "SHA-256",
+                    "000102030405060708090a0b0c0d0e0f" +
+                    "101112131415161718191a1b1c1d1e1f" +
+                    "202122232425262728292a2b2c2d2e2f" +
+                    "303132333435363738393a3b3c3d3e3f" +
+                    "404142434445464748494a4b4c4d4e4f",
+                    "606162636465666768696a6b6c6d6e6f" +
+                    "707172737475767778797a7b7c7d7e7f" +
+                    "808182838485868788898a8b8c8d8e8f" +
+                    "909192939495969798999a9b9c9d9e9f" +
+                    "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+                    "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" +
+                    "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf" +
+                    "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf" +
+                    "e0e1e2e3e4e5e6e7e8e9eaebecedeeef" +
+                    "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+                    82,
+                    "06a6b88c5853361a06104c9ceb35b45c" +
+                    "ef760014904671014a193f40c15fc244",
+                    "b11e398dc80327a1c8e7f78c596a4934" +
+                    "4f012eda2d4efad8a050cc4c19afa97c" +
+                    "59045a99cac7827271cb41c65e590e09" +
+                    "da3275600c2f09b8367793a9aca3db71" +
+                    "cc30c58179ec3e87c14c01d5c1f3434f" +
+                    "1d87"
+                },
+                {
+                    "SHA-256",
+                    "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+                    "",
+                    "",
+                    42,
+                    "19ef24a32c717b167f33a91d6f648bdf" +
+                    "96596776afdb6377ac434c1c293ccb04",
+                    "8da4e775a563c18f715f802a063c5a31" +
+                    "b8a11f5c5ee1879ec3454e5f3c738d2d" +
+                    "9d201395faa4b61a96c8"
+                },
+                {
+                    "SHA-1",
+                    "0b0b0b0b0b0b0b0b0b0b0b",
+                    "000102030405060708090a0b0c",
+                    "f0f1f2f3f4f5f6f7f8f9",
+                    42,
+                    "9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243",
+                    "085a01ea1b10f36933068b56efa5ad81" +
+                    "a4f14b822f5b091568a9cdd4f155fda2" +
+                    "c22e422478d305f3f896"
+                },
+                {
+                    "SHA-1",
+                    "000102030405060708090a0b0c0d0e0f" +
+                    "101112131415161718191a1b1c1d1e1f" +
+                    "202122232425262728292a2b2c2d2e2f" +
+                    "303132333435363738393a3b3c3d3e3f" +
+                    "404142434445464748494a4b4c4d4e4f",
+                    "606162636465666768696a6b6c6d6e6f" +
+                    "707172737475767778797a7b7c7d7e7f" +
+                    "808182838485868788898a8b8c8d8e8f" +
+                    "909192939495969798999a9b9c9d9e9f" +
+                    "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+                    "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" +
+                    "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf" +
+                    "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf" +
+                    "e0e1e2e3e4e5e6e7e8e9eaebecedeeef" +
+                    "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+                    82,
+                    "8adae09a2a307059478d309b26c4115a224cfaf6",
+                    "0bd770a74d1160f7c9f12cd5912a06eb" +
+                    "ff6adcae899d92191fe4305673ba2ffe" +
+                    "8fa3f1a4e5ad79f3f334b3b202b2173c" +
+                    "486ea37ce3d397ed034c7f9dfeb15c5e" +
+                    "927336d0441f4c4300e2cff0d0900b52" +
+                    "d3b4"
+                },
+                {
+                    "SHA-1",
+                    "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+                    "",
+                    "",
+                    42,
+                    "da8c8a73c7fa77288ec6f5e7c297786aa0d32d01",
+                    "0ac1af7002b3d761d1e55298da9d0506" +
+                    "b9ae52057220a306e07b6b87e8df21d0" +
+                    "ea00033de03984d34918"
+                },
+                {
+                    "SHA-1",
+                    "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c",
+                    null,
+                    "",
+                    42,
+                    "2adccada18779e7c2077ad2eb19d3f3e731385dd",
+                    "2c91117204d745f3500d636a62f64f0a" +
+                    "b3bae548aa53d423b0d1f27ebba6f5e5" +
+                    "673a081d70cce7acfc48"
+                }
+        };
+    }
+
+    @Test(dataProvider = "rfc5869TestVectors")
+    public void shouldMatchRfc5869TestVectors(String hashAlg, String ikmHex, String saltHex, String infoHex,
+            int outputLength, String expectedPrkHex, String outputKeyMaterialHex) {
+        // Given
+        var hmacAlg = "Hmac" + hashAlg.replace("-", "");
+        var hkdf = new HKDF(hmacAlg);
+
+        // When
+        var prk = hkdf.extract(saltHex == null ? null : fromHex(saltHex), fromHex(ikmHex));
+        var okm = hkdf.expand(prk, fromHex(infoHex), outputLength);
+
+        assertThat(prk.getEncoded()).asHexString().isEqualToIgnoringCase(expectedPrkHex);
+        assertThat(okm).asHexString().isEqualToIgnoringCase(outputKeyMaterialHex);
+    }
+}

--- a/src/test/java/software/pando/crypto/nacl/Poly1305Test.java
+++ b/src/test/java/software/pando/crypto/nacl/Poly1305Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Neil Madden.
+ * Copyright 2019-2022 Neil Madden.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 
 package software.pando.crypto.nacl;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.assertj.core.internal.Digests;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
-import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class Poly1305Test {
 
@@ -71,11 +71,7 @@ public class Poly1305Test {
     }
 
     private static byte[] fromHex(String hex) {
-        byte[] bytes = new BigInteger(hex.replaceAll("[^0-9a-fA-F]", ""), 16).toByteArray();
-        if (bytes[0] == 0) {
-            return Arrays.copyOfRange(bytes, 1, bytes.length);
-        }
-        return bytes;
+        return Digests.fromHex(hex.replaceAll("[^0-9a-fA-F]", ""));
     }
 
 }

--- a/src/test/java/software/pando/crypto/nacl/Salsa20Test.java
+++ b/src/test/java/software/pando/crypto/nacl/Salsa20Test.java
@@ -206,7 +206,7 @@ public class Salsa20Test {
         // Then - exception
     }
 
-    private static byte[] bytes(int...ints) {
+    static byte[] bytes(int...ints) {
         byte[] bytes = new byte[ints.length];
         for (int i = 0; i < ints.length; ++i) {
             bytes[i] = (byte)(ints[i]);

--- a/src/test/java/software/pando/crypto/nacl/Salsa20Test.java
+++ b/src/test/java/software/pando/crypto/nacl/Salsa20Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Neil Madden.
+ * Copyright 2019-2022 Neil Madden.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package software.pando.crypto.nacl;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class Salsa20Test {
 
@@ -119,6 +119,91 @@ public class Salsa20Test {
                 121,201,202,203,204, 205,206,207,208,209,210,211,212,
                 213,214,215,216,116,101, 32,107
         );
+    }
+
+    @Test
+    public void shouldHandle32BitSignedBlockCounterOverflow() {
+        // Given
+        byte[] key = bytes(
+                0x1b, 0x27, 0x55, 0x64, 0x73, 0xe9, 0x85,
+                0xd4, 0x62, 0xcd, 0x51, 0x19, 0x7a, 0x9a,
+                0x46, 0xc7, 0x60, 0x09, 0x54, 0x9e, 0xac,
+                0x64, 0x74, 0xf2, 0x06, 0xc4, 0xee, 0x08,
+                0x44, 0xf6, 0x83, 0x89);
+        byte[] nonce = bytes(
+                0x69, 0x69, 0x6e, 0xe9, 0x55, 0xb6, 0x2b, 0x73,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+        String expectedHex = "d9c95f12ce90f21b9e815b7cc4887a9a1ff04a7ec6365c62a8f9172b5157cd4acfb0353a7b9098dd3f47" +
+                "e383bae4cfcb03b7761a282c518c0d0229402f7299a170be9276af6f231c04c62a51cc28f07c7cbc6666abf04c5758f31" +
+                "51e6bf612f381b89d8b8b54869dc847ee1eaa6c1c7c9ce9c638d825c76eeabf41872f196767";
+
+        // When
+        ByteBuffer.wrap(nonce).order(ByteOrder.LITTLE_ENDIAN)
+                .asLongBuffer()
+                .put(1, Integer.MAX_VALUE);
+        byte[] data = new byte[128];
+        Salsa20.encrypt(key, nonce, data);
+
+        // Then
+        assertThat(data)
+                .asHexString()
+                .isEqualToIgnoringCase(expectedHex);
+    }
+
+    @Test
+    public void shouldHandle32BitUnsignedBlockCounterOverflow() {
+        byte[] key = bytes(
+                0x1b, 0x27, 0x55, 0x64, 0x73, 0xe9, 0x85,
+                0xd4, 0x62, 0xcd, 0x51, 0x19, 0x7a, 0x9a,
+                0x46, 0xc7, 0x60, 0x09, 0x54, 0x9e, 0xac,
+                0x64, 0x74, 0xf2, 0x06, 0xc4, 0xee, 0x08,
+                0x44, 0xf6, 0x83, 0x89);
+        byte[] nonce = bytes(
+                0x69, 0x69, 0x6e, 0xe9, 0x55, 0xb6, 0x2b, 0x73,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+        String expectedHex = "60235422f7060426a5d88fa8b10870690421b0a421b35dadf82f16949f74a53d33f7410ac10f2d787ab8" +
+                "41f5c22c690c74ac9a8c519413b54419239bf0feeeab09fbecd7a61e40aa54c34f7e7346099e3b1b5f95c6195c26b268a" +
+                "4532c5fce9a3d0f020d85347b816c4b0edd50c89d663bb10c4216a134309471f163758295ed";
+
+        // When
+        ByteBuffer.wrap(nonce).order(ByteOrder.LITTLE_ENDIAN)
+                .asLongBuffer()
+                .put(1, (1L << 32) - 1L);
+        byte[] data = new byte[128];
+        Salsa20.encrypt(key, nonce, data);
+
+        // Then
+        assertThat(data)
+                .asHexString()
+                .isEqualToIgnoringCase(expectedHex);
+    }
+
+    /**
+     * Technically, XSalsa20 can support the full range of a 64-bit long as the block counter. For implementation
+     * simplicity in Java, we only support up to Long.MAX_VALUE (i.e. 2^63-1). Although it is extremely unlikely that
+     * this limit will ever be reached, for safety we raise an exception if it is.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfBlockCounterExceedsSigned64BitLong() {
+        // Given
+        byte[] key = bytes(
+                0x1b, 0x27, 0x55, 0x64, 0x73, 0xe9, 0x85,
+                0xd4, 0x62, 0xcd, 0x51, 0x19, 0x7a, 0x9a,
+                0x46, 0xc7, 0x60, 0x09, 0x54, 0x9e, 0xac,
+                0x64, 0x74, 0xf2, 0x06, 0xc4, 0xee, 0x08,
+                0x44, 0xf6, 0x83, 0x89);
+        byte[] nonce = bytes(
+                0x69, 0x69, 0x6e, 0xe9, 0x55, 0xb6, 0x2b, 0x73,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+
+        // When
+        ByteBuffer.wrap(nonce).order(ByteOrder.LITTLE_ENDIAN)
+                .asLongBuffer()
+                .put(1, Long.MAX_VALUE);
+        byte[] data = new byte[128];
+        Salsa20.encrypt(key, nonce, data);
+
+        // Then - exception
     }
 
     private static byte[] bytes(int...ints) {

--- a/src/test/java/software/pando/crypto/nacl/SubtleTest.java
+++ b/src/test/java/software/pando/crypto/nacl/SubtleTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 Neil Madden.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.pando.crypto.nacl;
+
+import org.testng.annotations.Test;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.internal.Digests.fromHex;
+import static software.pando.crypto.nacl.Salsa20Test.bytes;
+
+public class SubtleTest {
+
+    @Test
+    public void testConstants() {
+        assertSoftly(softly -> {
+            softly.assertThat(Subtle.XSALSA20_KEY_SIZE).isEqualTo(32);
+            softly.assertThat(Subtle.XSALSA20_NONCE_SIZE).isEqualTo(24);
+        });
+    }
+
+    @Test
+    public void scalarMultiplicationShouldMatchRfc7748TestVector1() {
+        byte[] scalar = fromHex("a546e36bf0527c9d3b16154b82465edd62144c0ac1fc5a18506a2244ba449ac4");
+        byte[] point = fromHex("e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c");
+        byte[] result = Subtle.scalarMultiplication(scalar, point);
+        assertThat(result).asHexString()
+                .isEqualToIgnoringCase("c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552");
+    }
+
+    @Test
+    public void scalarMultiplicationShouldMatchRfc7748TestVector2() {
+        byte[] scalar = fromHex("4b66e9d4d1b4673c5ad22691957d6af5c11b6421e0ea01d42ca4169e7918ba0d");
+        byte[] point = fromHex("e5210f12786811d3f4b7959d0538ae2c31dbe7106fc03c3efc4cd549c715a493");
+        byte[] result = Subtle.scalarMultiplication(scalar, point);
+        assertThat(result).asHexString()
+                .isEqualToIgnoringCase("95cbde9476e8907d7aade45cb4b873f88b595a68799fa152e6f8f7647aac7957");
+    }
+
+    @Test
+    public void scalarMultiplicationShouldMatchRfc7748IteratedTestVectorAfter1Round() {
+        byte[] scalar = fromHex("0900000000000000000000000000000000000000000000000000000000000000");
+        byte[] point = fromHex("0900000000000000000000000000000000000000000000000000000000000000");
+        byte[] result = Subtle.scalarMultiplication(scalar, point);
+        assertThat(result).asHexString()
+                .isEqualToIgnoringCase("422c8e7a6227d7bca1350b3e2bb7279f7897b87bb6854b783c60e80311ae3079");
+    }
+
+    @Test
+    public void scalarMultiplicationShouldMatchRfc7748IteratedTestVectorAfter1000Rounds() {
+        byte[] scalar = fromHex("0900000000000000000000000000000000000000000000000000000000000000");
+        byte[] point = fromHex("0900000000000000000000000000000000000000000000000000000000000000");
+
+        for (int i = 0; i < 1000; ++i) {
+            byte[] tmp = Subtle.scalarMultiplication(scalar, point);
+            point = scalar;
+            scalar = tmp;
+        }
+        assertThat(scalar).asHexString()
+                .isEqualToIgnoringCase("684cf59ba83309552800ef566f2f4d3c1c3887c49360e3875f2eb94d99532c51");
+    }
+
+    @Test(enabled = false) // This test is extremely slow and CPU-intensive so disabled by default
+    public void scalarMultiplicationShouldMatchRfc7748IteratedTestVectorAfter1000000Rounds() {
+        byte[] scalar = fromHex("0900000000000000000000000000000000000000000000000000000000000000");
+        byte[] point = fromHex("0900000000000000000000000000000000000000000000000000000000000000");
+
+        for (int i = 0; i < 1_000_000; ++i) {
+            byte[] tmp = Subtle.scalarMultiplication(scalar, point);
+            point = scalar;
+            scalar = tmp;
+        }
+        assertThat(scalar).asHexString()
+                .isEqualToIgnoringCase("7c3911e0ab2586fd864497297e575e6f3bc601c0883c30df5f4dd2d24f665424");
+    }
+
+    @Test
+    public void streamShouldMatchLibsodiumTestVector1() {
+        // Given
+        byte[] firstkey = bytes(
+                0x1b, 0x27, 0x55, 0x64, 0x73, 0xe9, 0x85, 0xd4, 0x62, 0xcd, 0x51, 0x19, 0x7a, 0x9a, 0x46, 0xc7,
+                0x60, 0x09, 0x54, 0x9e, 0xac, 0x64, 0x74, 0xf2, 0x06, 0xc4, 0xee, 0x08, 0x44, 0xf6, 0x83, 0x89);
+        byte[] nonce = bytes(
+                0x69, 0x69, 0x6e, 0xe9, 0x55, 0xb6, 0x2b, 0x73, 0xcd, 0x62, 0xbd, 0xa8, 0x75, 0xfc, 0x73, 0xd6,
+                0x82, 0x19, 0xe0, 0x03, 0x6b, 0x7a, 0x0b, 0x37);
+        ByteSlice output = ByteSlice.of(new byte[4194304]);
+
+        // When
+        Subtle.streamXSalsa20(Subtle.streamXSalsa20Key(firstkey), nonce).process(output);
+
+        // Then
+        assertThat(sha256(output.array)).asHexString()
+                .isEqualToIgnoringCase("662b9d0e3463029156069b12f918691a98f7dfb2ca0393c96bbfc6b1fbd630a2");
+    }
+
+    private static byte[] sha256(byte[] data) {
+        try {
+            var hash = MessageDigest.getInstance("SHA-256");
+            return hash.digest(data);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the following new features:

- Key derivation functions based on HKDF-SHA-512
- A multiple-input MAC function, based on the safe cascade construction from https://neilmadden.blog/2021/10/27/multiple-input-macs/
- A new public `Subtle` class exposing low-level primitives: X25519 scalar multiplication, and XSalsa20 unauthenticated stream cipher.
- A new public `ByteSlice` class that simplifies and unifies handling of byte arrays in some APIs (more to be converted in future).

This also fixes some minor bugs and updates the Tink crypto code to the latest (only upstream change is the introduction of private constructors for utility classes).